### PR TITLE
Security: fix CVE-2026-57297, CVE-2026-57298 in ContrastPluginConfig

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastPluginConfig.java
@@ -5,6 +5,7 @@ import com.contrastsecurity.models.Organizations;
 import com.contrastsecurity.sdk.ContrastSDK;
 import hudson.Extension;
 import hudson.model.AbstractProject;
+import hudson.model.Item;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.model.Result;
@@ -16,12 +17,16 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -103,7 +108,10 @@ public class ContrastPluginConfig extends JobProperty<AbstractProject<?, ?>> {
         }
 
         @SuppressWarnings("unused")
-        public ListBoxModel doFillTeamServerProfileNameItems() {
+        public ListBoxModel doFillTeamServerProfileNameItems(@AncestorInPath Item item) {
+            if (!hasFillPermission(item)) {
+                return new ListBoxModel();
+            }
             return VulnerabilityTrendHelper.getProfileNames();
         }
 
@@ -112,8 +120,18 @@ public class ContrastPluginConfig extends JobProperty<AbstractProject<?, ?>> {
          *
          * @return ListBoxModel filled with vulnerability types.
          */
-        public ListBoxModel doFillThresholdVulnTypeItems(@QueryParameter("teamServerProfileName") final String teamServerProfileName) throws IOException {
+        public ListBoxModel doFillThresholdVulnTypeItems(@AncestorInPath Item item, @QueryParameter("teamServerProfileName") final String teamServerProfileName) throws IOException {
+            if (!hasFillPermission(item)) {
+                return new ListBoxModel();
+            }
             return VulnerabilityTrendHelper.getVulnerabilityTypes(teamServerProfileName);
+        }
+
+        private static boolean hasFillPermission(Item item) {
+            if (item == null) {
+                return Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER);
+            }
+            return item.hasPermission(Item.CONFIGURE);
         }
 
         /**
@@ -127,10 +145,13 @@ public class ContrastPluginConfig extends JobProperty<AbstractProject<?, ?>> {
          * @throws IOException
          * @throws ServletException
          */
+        @RequirePOST
         public FormValidation doTestTeamServerConnection(@QueryParameter("username") final String username,
                                                          @QueryParameter("apiKey") final Secret apiKey,
                                                          @QueryParameter("serviceKey") final Secret serviceKey,
                                                          @QueryParameter("teamServerUrl") final String teamServerUrl) throws IOException, ServletException {
+
+            Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER);
 
             if (StringUtils.isEmpty(username)) {
                 return FormValidation.error("Connection error: Username cannot be empty.");
@@ -148,8 +169,20 @@ public class ContrastPluginConfig extends JobProperty<AbstractProject<?, ?>> {
                 return FormValidation.error("Connection error: Contrast URL cannot be empty.");
             }
 
-            if (!teamServerUrl.endsWith("/Contrast/api")) {
-                return FormValidation.error("Connection error: Contrast Url does not end with /Contrast/api.");
+            try {
+                URL parsedUrl = new URL(teamServerUrl);
+                String protocol = parsedUrl.getProtocol();
+                if (!protocol.equals("http") && !protocol.equals("https")) {
+                    return FormValidation.error("Connection error: Contrast URL must use http or https.");
+                }
+                if (StringUtils.isEmpty(parsedUrl.getHost())) {
+                    return FormValidation.error("Connection error: Contrast URL is not a valid URL.");
+                }
+                if (!parsedUrl.getPath().equals("/Contrast/api")) {
+                    return FormValidation.error("Connection error: Contrast URL does not end with /Contrast/api.");
+                }
+            } catch (MalformedURLException e) {
+                return FormValidation.error("Connection error: Contrast URL is not a valid URL.");
             }
 
             try {


### PR DESCRIPTION
## Summary

Fixes two CVEs in `ContrastPluginConfig.doTestTeamServerConnection` and hardens two additional `doFill*` endpoints in the same class.

- **CVE-2026-57297** (missing permission check): `doTestTeamServerConnection` was reachable by any Overall/Read user. An attacker could supply arbitrary `username`, `apiKey`, `serviceKey`, and `teamServerUrl` to trigger an outbound HTTP call using attacker-controlled credentials against an attacker-specified URL.
- **CVE-2026-57298** (CSRF): the same endpoint accepted GET requests, making it exploitable via cross-site request forgery.
- **doFill* hardening**: `doFillTeamServerProfileNameItems` and `doFillThresholdVulnTypeItems` exposed locally-cached Jenkins config to any Overall/Read user with no permission check.
- **SSRF hardening** (defense-in-depth): replaced `endsWith("/Contrast/api")` with full `java.net.URL` parsing enforcing `http`/`https` protocol, non-empty host, and exact path.

## Changes

- `@RequirePOST` added to `doTestTeamServerConnection`
- `Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER)` added as first statement in `doTestTeamServerConnection`
- `doFillTeamServerProfileNameItems` and `doFillThresholdVulnTypeItems` gated behind `hasFillPermission(Item item)` helper
- URL validation replaced with `java.net.URL` parse + protocol/host/path enforcement

## Test plan

- [ ] Verify Overall/Read user cannot invoke `doTestTeamServerConnection` via GET or POST
- [ ] Verify CSRF token is required for `doTestTeamServerConnection`
- [ ] Verify Overall/Read user receives empty dropdown for profile name and vuln type selectors
- [ ] Verify Jenkins admin can test connection and populate all dropdowns in global config
- [ ] Verify non-http/https URLs (e.g. `file://`, `ftp://`) are rejected at URL validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)