### PR TITLE
Security: add permission guards to doFill* in VulnerabilityTrendRecorder and ContrastAgentStep

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastAgentStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ContrastAgentStep.java
@@ -5,6 +5,7 @@ import com.google.inject.Inject;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.IOUtils;
@@ -16,6 +17,7 @@ import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -83,8 +85,18 @@ public class ContrastAgentStep extends AbstractStepImpl {
 
 
         @SuppressWarnings("unused")
-        public ListBoxModel doFillProfileItems() {
+        public ListBoxModel doFillProfileItems(@AncestorInPath Item item) {
+            if (!hasFillPermission(item)) {
+                return new ListBoxModel();
+            }
             return VulnerabilityTrendHelper.getProfileNames();
+        }
+
+        private static boolean hasFillPermission(Item item) {
+            if (item == null) {
+                return Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER);
+            }
+            return item.hasPermission(Item.CONFIGURE);
         }
 
         @SuppressWarnings("unused")

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendRecorder.java
@@ -16,6 +16,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BuildListener;
+import hudson.model.Item;
 import hudson.model.Result;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
@@ -27,6 +28,7 @@ import lombok.Getter;
 import lombok.Setter;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
@@ -445,8 +447,18 @@ public class VulnerabilityTrendRecorder extends Recorder {
         }
 
         @SuppressWarnings("unused")
-        public ListBoxModel doFillTeamServerProfileNameItems() {
+        public ListBoxModel doFillTeamServerProfileNameItems(@AncestorInPath Item item) {
+            if (!hasFillPermission(item)) {
+                return new ListBoxModel();
+            }
             return VulnerabilityTrendHelper.getProfileNames();
+        }
+
+        private static boolean hasFillPermission(Item item) {
+            if (item == null) {
+                return Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER);
+            }
+            return item.hasPermission(Item.CONFIGURE);
         }
 
         /**


### PR DESCRIPTION
## Summary

`doFillTeamServerProfileNameItems` (VulnerabilityTrendRecorder) and `doFillProfileItems` (ContrastAgentStep) were accessible to any Overall/Read user with no authorization check. Both return the names of all configured Contrast TeamServer profiles from Jenkins global config.

- `doFillTeamServerProfileNameItems` in `VulnerabilityTrendRecorder.DescriptorImpl` — gated behind `hasFillPermission`
- `doFillProfileItems` in `ContrastAgentStep` descriptor — gated behind `hasFillPermission`
- `doFillAgentTypeItems` returns a static list with no config data — left unchanged

**Fix pattern:** `hasFillPermission(Item item)` requires `Jenkins.ADMINISTER` in global config context (item is null), or `Item.CONFIGURE` in job config context. Each guarded method accepts `@AncestorInPath Item item` as its first parameter.

## Test plan

- [ ] Verify Overall/Read user receives an empty profile dropdown in VulnerabilityTrendRecorder job config
- [ ] Verify Overall/Read user receives an empty profile dropdown in ContrastAgentStep pipeline step config
- [ ] Verify Item.CONFIGURE user can populate profile dropdowns in job context
- [ ] Verify Jenkins admin can populate profile dropdowns in global context

🤖 Generated with [Claude Code](https://claude.com/claude-code)