### PR TITLE
Security: add permission guards to doFill* in VulnerabilityTrendStep and ThresholdCondition

### DIFF
--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/ThresholdCondition.java
@@ -7,12 +7,14 @@ import hudson.Extension;
 import hudson.RelativePath;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.model.Item;
 import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import lombok.Getter;
 import lombok.Setter;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -303,8 +305,10 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
          *
          * @return ComboBoxModel filled with application ids.
          */
-        public ComboBoxModel doFillApplicationIdItems(@QueryParameter("teamServerProfileName") @RelativePath("..") final String teamServerProfileName) {
-
+        public ComboBoxModel doFillApplicationIdItems(@AncestorInPath Item item, @QueryParameter("teamServerProfileName") @RelativePath("..") final String teamServerProfileName) {
+            if (!hasFillPermission(item)) {
+                return new ComboBoxModel();
+            }
             // Refresh apps every ${appsRefreshIntervalMinutes} minutes before filling in the combobox
             if (lastAppsRefresh == null || (Calendar.getInstance().getTimeInMillis() - lastAppsRefresh.getTimeInMillis()) / 60000 >= appsRefreshIntervalMinutes) {
                 refreshApps(teamServerProfileName);
@@ -337,7 +341,10 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
          *
          * @return ListBoxModel filled with vulnerability types.
          */
-        public ListBoxModel doFillThresholdVulnTypeItems(@QueryParameter("teamServerProfileName") @RelativePath("..") final String teamServerProfileName) throws IOException {
+        public ListBoxModel doFillThresholdVulnTypeItems(@AncestorInPath Item item, @QueryParameter("teamServerProfileName") @RelativePath("..") final String teamServerProfileName) throws IOException {
+            if (!hasFillPermission(item)) {
+                return new ListBoxModel();
+            }
             return VulnerabilityTrendHelper.getVulnerabilityTypes(teamServerProfileName);
         }
 
@@ -357,6 +364,13 @@ public class ThresholdCondition extends AbstractDescribableImpl<ThresholdConditi
          */
         public String getDisplayName() {
             return "Threshold Condition";
+        }
+
+        private static boolean hasFillPermission(Item item) {
+            if (item == null) {
+                return Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER);
+            }
+            return item.hasPermission(Item.CONFIGURE);
         }
     }
 

--- a/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
+++ b/src/main/java/com/aspectsecurity/contrast/contrastjenkins/VulnerabilityTrendStep.java
@@ -11,6 +11,7 @@ import com.google.inject.Inject;
 import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.Extension;
+import hudson.model.Item;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -22,6 +23,7 @@ import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -217,7 +219,10 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
         }
 
         @SuppressWarnings("unused")
-        public ListBoxModel doFillProfileItems() {
+        public ListBoxModel doFillProfileItems(@AncestorInPath Item item) {
+            if (!hasFillPermission(item)) {
+                return new ListBoxModel();
+            }
             return VulnerabilityTrendHelper.getProfileNames();
         }
 
@@ -226,18 +231,31 @@ public class VulnerabilityTrendStep extends AbstractStepImpl {
          *
          * @return ListBoxModel filled with application ids.
          */
-        public ListBoxModel doFillApplicationIdItems(@QueryParameter("profile") final String teamServerProfileName) throws IOException {
+        public ListBoxModel doFillApplicationIdItems(@AncestorInPath Item item, @QueryParameter("profile") final String teamServerProfileName) throws IOException {
+            if (!hasFillPermission(item)) {
+                return new ListBoxModel();
+            }
             return VulnerabilityTrendHelper.getApplicationIds(teamServerProfileName);
         }
 
         @SuppressWarnings("unused")
-        public ListBoxModel doFillRuleItems(@QueryParameter("profile") final String teamServerProfileName) {
+        public ListBoxModel doFillRuleItems(@AncestorInPath Item item, @QueryParameter("profile") final String teamServerProfileName) {
+            if (!hasFillPermission(item)) {
+                return new ListBoxModel();
+            }
             return VulnerabilityTrendHelper.getVulnerabilityTypes(teamServerProfileName);
         }
 
         @SuppressWarnings("unused")
         public ListBoxModel doFillSeverityItems() {
             return VulnerabilityTrendHelper.getSeverityListBoxModel();
+        }
+
+        private static boolean hasFillPermission(Item item) {
+            if (item == null) {
+                return Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER);
+            }
+            return item.hasPermission(Item.CONFIGURE);
         }
     }
 


### PR DESCRIPTION
## Summary

**Highest-severity finding in this batch:** `ThresholdCondition.doFillApplicationIdItems` had no permission check and conditionally called `refreshApps()`, which instantiated `ContrastSDK` using Jenkins-stored credentials and made an outbound HTTP call to the configured Contrast TeamServer. Any Overall/Read user could trigger this call.

**All endpoints fixed:**

`ThresholdCondition` (DescriptorImpl):
- `doFillApplicationIdItems` — permission guard added before `refreshApps()` call; outbound HTTP blocked for unprivileged callers
- `doFillThresholdVulnTypeItems` — permission guard added; returned cached vuln types from stored config

`VulnerabilityTrendStep` (VulnerabilityTrendStepDescriptorImpl):
- `doFillProfileItems` — permission guard added
- `doFillApplicationIdItems` — permission guard added
- `doFillRuleItems` — permission guard added

Static-list endpoints (`doFillSeverityItems`, `doFillThresholdSeverityItems`, `doFillAgentTypeItems`) and all `doCheck*` methods left unchanged.

**Fix pattern:** `hasFillPermission(Item item)` requires `Jenkins.ADMINISTER` in global context, `Item.CONFIGURE` in job context. Each method receives `@AncestorInPath Item item` as its first parameter.

## Test plan

- [ ] Verify Overall/Read user cannot populate ThresholdCondition application ID dropdown
- [ ] Verify no outbound HTTP call to TeamServer occurs when permission check fails on `doFillApplicationIdItems`
- [ ] Verify Overall/Read user cannot populate VulnerabilityTrendStep profile, application ID, or rule dropdowns
- [ ] Verify Item.CONFIGURE user can populate all dropdowns in job config context
- [ ] Verify Jenkins admin can populate all dropdowns in global config context

🤖 Generated with [Claude Code](https://claude.com/claude-code)